### PR TITLE
Modularize travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ matrix:
       os:
         - linux
       env:
-        - KIND=ocaml
         - LANG=multicore-ocaml
+        - KIND=ocaml
 
     # Eff
     - language: c
@@ -18,8 +18,8 @@ matrix:
       os:
         - linux
       env:
-        - KIND=ocaml
         - LANG=eff
+        - KIND=ocaml
 
     # Frank
     - language: c
@@ -28,13 +28,13 @@ matrix:
       os:
         - linux
       env:
-        - KIND=haskell
         - LANG=frank
+        - KIND=haskell
 
     # Scala Effekt
     - language: scala
-      jdk:
-      - oraclejdk8
+      script:
+        - jdk_switcher use oraclejdk8
       cache:
         directories:
           - $HOME/.ivy2/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
       os:
         - linux
       env:
-        - LANG=multicore-ocaml
+        - PROGLANG=multicore-ocaml
         - KIND=ocaml
 
     # Eff
@@ -18,7 +18,7 @@ matrix:
       os:
         - linux
       env:
-        - LANG=eff
+        - PROGLANG=eff
         - KIND=ocaml
 
     # Frank
@@ -28,7 +28,7 @@ matrix:
       os:
         - linux
       env:
-        - LANG=frank
+        - PROGLANG=frank
         - KIND=haskell
 
     # Scala Effekt
@@ -39,9 +39,10 @@ matrix:
             - oracle-java8-installer
       jvm:
         - oraclejdk8
+      script: make all
       cache:
         directories:
           - $HOME/.ivy2/cache
           - $HOME/.sbt
       env:
-        - LANG=scala-effekt
+        - PROGLANG=scala-effekt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,43 @@
-language: c
-sudo: required
-script: bash -ex .travis.sh
-os:
-  - linux
-env:
-  - KIND=ocaml
-  - KIND=haskell
+matrix:
+  include:
+
+    # Multicore OCaml
+    - language: c
+      sudo: required
+      script: bash -ex .travis.sh
+      os:
+        - linux
+      env:
+        - KIND=ocaml
+        - LANG=multicore-ocaml
+
+    # Eff
+    - language: c
+      sudo: required
+      script: bash -ex .travis.sh
+      os:
+        - linux
+      env:
+        - KIND=ocaml
+        - LANG=eff
+
+    # Frank
+    - language: c
+      sudo: required
+      script: bash -ex .travis.sh
+      os:
+        - linux
+      env:
+        - KIND=haskell
+        - LANG=frank
+
+    # Scala Effekt
+    - language: scala
+      jdk:
+      - oraclejdk8
+      cache:
+        directories:
+          - $HOME/.ivy2/cache
+          - $HOME/.sbt
+      env:
+        - LANG=scala-effekt

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,12 @@ matrix:
 
     # Scala Effekt
     - language: scala
-      script:
-        - jdk_switcher use oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+      jvm:
+        - oraclejdk8
       cache:
         directories:
           - $HOME/.ivy2/cache

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 TOPTARGETS := all clean
 
-SUBDIRS := $(wildcard */*/.)
+PROGLANG ?= *
 
+SUBDIRS := $(wildcard examples/*/$(PROGLANG)/.)
 $(TOPTARGETS): $(SUBDIRS)
 $(SUBDIRS):
 	$(MAKE) -C $@ $(MAKECMDGOALS)


### PR DESCRIPTION
As suggested in #5 by @kayceesrk, I started modularizing the travis build by explicitly listing all programming languages in the build matrix. The environment variable `PROGLANG` is used to only select the folder of the corresponding language in the make file.

[Here is a a build job](https://travis-ci.org/b-studios/effects-rosetta-stone/builds/377715562) using this config.

@kayceesrk Could you review the ocaml setup? Is it really necessary to build ocaml every time? Can we cache this?